### PR TITLE
Log with INFO the exclusion of seeds

### DIFF
--- a/pkg/convert.go
+++ b/pkg/convert.go
@@ -41,7 +41,7 @@ func seedCanBeUsed(seed *gardener_types.Seed) bool {
 
 	result := isDeletionTimesampt && seed.Spec.Settings.Scheduling.Visible && isReady && hasNoTaints
 	if !result {
-		slog.Debug("seed rejected",
+		slog.Info("seed rejected",
 			"name", seed.Name,
 			"isDeletionTimestamp", isDeletionTimesampt,
 			"isVisible", isVisible,


### PR DESCRIPTION
**Description**

Log Seed-cluster exclusion with INFO log level instead with DEBUG.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
