### PR TITLE
Process BUILDPLATFORM in the Dockerfile to support cross-compilation 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24.4-alpine3.21 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.4-alpine3.22 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
Apply recomendation from https://github.com/kyma-project/test-infra/tree/main/cmd/image-builder#cross-compiling-and-caching-for-non-native-architecture-builds