### PR TITLE
Using distroless as a minimal base image to package the binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-# FROM gcr.io/distroless/static:nonroot
-FROM alpine:latest
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /project_workspace/manager .
 USER 65532:65532


### PR DESCRIPTION
Change from alpine to  https://github.com/GoogleContainerTools/distroless