### PR TITLE
fix: Update Go version to 1.26.2 for consistency and setup-envtest compatibility

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -49,7 +49,7 @@ jobs:
     - name: Set up go environment
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25.6
+        go-version-file: go.mod
     - name: Run unit tests
       run: go test ./... -v -coverprofile=coverage.txt
     - name: Upload coverage artifact

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -42,7 +42,6 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-          /home/runner/work/gardener-syncer/gardener-syncer/bin
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.mod', '**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -43,7 +43,7 @@ jobs:
           ~/.cache/go-build
           ~/go/pkg/mod
           /home/runner/work/gardener-syncer/gardener-syncer/bin
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.mod', '**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Set up go environment

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -50,6 +50,7 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version-file: go.mod
+        cache: false
     - name: Run unit tests
       run: go test ./... -v -coverprofile=coverage.txt
     - name: Upload coverage artifact

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.25.6-alpine3.22 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine3.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/gardener-syncer
 
-go 1.25.1
+go 1.26.2
 
 require (
 	github.com/gardener/gardener v1.130.0


### PR DESCRIPTION
## Summary
This PR updates the Go version to 1.26.2 to align with other repositories in the project and ensure compatibility with the latest controller-runtime tooling.

## Changes
- Updated go.mod: Go 1.25.1 → 1.26.2
- Updated Dockerfile: golang:1.25.6-alpine3.22 → golang:1.26.2-alpine3.23
- Updated workflow to use go-version-file instead of hardcoded version (best practice)
- Ran go mod tidy

## Why
- The latest sigs.k8s.io/controller-runtime/tools/setup-envtest requires Go >= 1.26.0
- Ensures consistency across all repositories in the project
- Using go-version-file provides single source of truth for Go version
- Prevents CI failures due to Go version mismatches

## Testing
After merge, verify that CI checks pass successfully.