### PR TITLE
fix: Use go-version-file for dynamic Go version management

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -42,14 +42,14 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-          /home/runner/work/gardener-syncer/gardener-syncer/bin
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.mod', '**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Set up go environment
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25.6
+        go-version-file: go.mod
+        cache: false
     - name: Run unit tests
       run: go test ./... -v -coverprofile=coverage.txt
     - name: Upload coverage artifact


### PR DESCRIPTION
## Summary
This PR updates the test workflow to read the Go version from go.mod dynamically instead of hardcoding it. This is necessary to support PRs that update the Go version.

## Problem
The current workflow uses `pull_request_target` event (for security) which runs the workflow file from the **main branch**, not from the PR branch. When PRs try to update the Go version by changing go.mod, the hardcoded Go version in the workflow on main branch causes version mismatches:

```
go: go.mod requires go >= 1.26.2 (running go 1.25.6)
```

## Solution
Change the workflow to use `go-version-file: go.mod` which reads the Go version from the PR's go.mod file.

## Changes
- ✅ Use `go-version-file: go.mod` instead of hardcoded `go-version: 1.25.6`
- ✅ Disable setup-go internal cache (use external cache action instead)
- ✅ Update cache key to include go.mod hash for proper cache invalidation
- ✅ Remove workspace bin from cache path (shouldn't be cached)

## Impact
- ✅ Allows PRs to update Go version seamlessly
- ✅ Maintains security of pull_request_target workflow
- ✅ Single source of truth for Go version (go.mod)
- ✅ Will unblock PR #166 (Go version update to 1.26.2)

## Testing
After merge, PR #166 should pass CI checks as it will read Go 1.26.2 from its go.mod file.