### PR TITLE
Add release workflow for automated GitHub releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,9 +18,6 @@ jobs:
     permissions:
       contents: write  # Needed for creating releases and uploading assets
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
       - name: Create Release and Generate Notes
         uses: softprops/action-gh-release@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Create Release and Generate Notes
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,29 @@
+name: Gardener Syncer Release
+
+on:
+  push:
+    tags:
+      - '*'  # Trigger on tag pushes
+
+jobs:
+  run-release-tests:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/run-tests.yaml
+
+  generate-release:
+    needs: run-release-tests
+    if: needs.run-release-tests.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Needed for creating releases and uploading assets
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Create Release and Generate Notes
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a release workflow similar to KIM that:

1. Runs tests when a tag is pushed
2. Creates a GitHub release with auto-generated release notes
3. Triggers on any tag push

This will enable automated release creation when tags are pushed to the repository.

**Related to:** Standardizing release processes across Kyma components