### PR TITLE
Fix release workflow: remove broken reusable workflow call

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,6 +1,7 @@
 name: tests
 
 on:
+  workflow_call:
   push:
     branches:
       - main


### PR DESCRIPTION
## Problem

`release.yaml` calls `run-tests.yaml` as a reusable workflow via `uses:`, but `run-tests.yaml` was missing the `workflow_call` trigger. This caused the release workflow to fail immediately with a "workflow file issue", preventing GitHub releases from being created on tag push.

## Fix

Add `workflow_call:` to `run-tests.yaml`'s `on:` block, matching the pattern used in [kyma-infrastructure-manager](https://github.com/kyma-project/kyma-infrastructure-manager/blob/main/.github/workflows/run-tests.yaml).