### PR TITLE
Fix release workflow permissions for reusable workflow call

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,8 @@ jobs:
   run-release-tests:
     permissions:
       contents: read
+      actions: read
+      pull-requests: write
     uses: ./.github/workflows/run-tests.yaml
 
   generate-release:


### PR DESCRIPTION
## Problem

The release workflow calls `run-tests.yaml` as a reusable workflow, but only grants `contents: read`. The `code_coverage` job inside `run-tests.yaml` requests `pull-requests: write` and `actions: read`. When a reusable workflow's jobs request permissions beyond what the caller grants, GitHub fails with `startup_failure` before any job starts.

Link to failed workflow: https://github.com/kyma-project/gardener-syncer/actions/runs/24829704357 
## Fix

Add `actions: read` and `pull-requests: write` to the caller's permissions block so they cover all permissions requested by `run-tests.yaml` jobs.

Note: the `code_coverage` job only runs on `pull_request_target` events, so it won't actually execute during a release, but GitHub validates permissions at startup regardless.