### PR TITLE
Add gate job in workflows with pull_request_target

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,19 @@ permissions:
   contents: read # This is required for actions/checkout
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    environment: ${{ vars.PROTECTED_ENVIRONMENT }}
+    steps:
+      - name: Approve fork PR image build
+        run: echo "Image build approved for fork PR"
+
   setup:
+    needs: [gate]
+    if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -39,9 +51,9 @@ jobs:
       latest: ${{ steps.latest.outputs.latest || '' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - id: tag
         if: github.event_name == 'push' && github.ref_type == 'tag'
@@ -51,7 +63,10 @@ jobs:
         run: echo "latest=latest" >> $GITHUB_OUTPUT
 
   build-image:
-    needs: [setup]
+    needs: [setup, gate]
+    if: >-
+      needs.setup.result == 'success' &&
+      (needs.gate.result == 'success' || needs.gate.result == 'skipped')
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main # Usage: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: gardener-syncer
@@ -64,7 +79,7 @@ jobs:
   summary:
     runs-on: ubuntu-latest
     needs: [build-image]
-    if: success() || failure()
+    if: always() && contains(needs.*.result, 'success')
     steps:
       - name: "Generate summary"
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,17 +79,14 @@ jobs:
   summary:
     runs-on: ubuntu-latest
     needs: [build-image]
-    if: always() && contains(needs.*.result, 'success')
+    if: needs.build-image.result == 'success'
     steps:
       - name: "Generate summary"
         run: |
           {
             echo '# Gardener Syncer'
-            # if build-image was successful
-            if [ "${{ needs.build-image.result }}" == "success" ]; then
-              printf '\n\n## Image\n'
-              printf '\n```json\n'
-              echo '${{ needs.build-image.outputs.images }}' | jq
-              printf '\n```\n'
-            fi
+            printf '\n\n## Image\n'
+            printf '\n```json\n'
+            echo '${{ needs.build-image.outputs.images }}' | jq
+            printf '\n```\n'
           } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/lint-markdown-links.yml
+++ b/.github/workflows/lint-markdown-links.yml
@@ -5,7 +5,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: gaurav-nelson/github-action-markdown-link-check@0524e79d8d7d1606112722dd7a3b5f5ce367de3e
         with:
           use-verbose-mode: 'no'

--- a/.github/workflows/pull-gitleaks.yml
+++ b/.github/workflows/pull-gitleaks.yml
@@ -10,7 +10,7 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Fetch gitleaks ${{ env.GITLEAKS_VERSION }}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -62,7 +62,7 @@ jobs:
 
   code_coverage:
     name: "Code coverage report"
-    if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request'
+    if: github.event_name == 'workflow_call' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: unit-tests
     permissions:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -15,7 +15,7 @@ on:
       - .gitignore
       - "**.md"
 
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:
       - .reuse
@@ -33,9 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: ${{ github.event.pull_request.head.sha }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}
     - name: Set up cache
       uses: actions/cache@v4
@@ -62,7 +62,7 @@ jobs:
 
   code_coverage:
     name: "Code coverage report"
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: unit-tests
     permissions:


### PR DESCRIPTION
# Add Gate Job to Build Workflow for Fork PR Security

### New Features

🔒 **Security Enhancement**: Introduced a `gate` job in the build workflow to enforce manual approval for PRs originating from forked repositories when using `pull_request_target`. This prevents untrusted code from accessing repository secrets without explicit approval via a protected environment.

### Changes

* `.github/workflows/build.yaml`:
  - Added a `gate` job that runs only for fork PRs (when `head.repo.full_name != github.repository`) and requires approval via a protected environment (`vars.PROTECTED_ENVIRONMENT`).
  - Updated `setup` and `build-image` jobs to depend on `gate`, proceeding only when `gate` succeeded or was skipped (i.e., for non-fork PRs).
  - Updated `summary` job condition from `success() || failure()` to `always() && contains(needs.*.result, 'success')` to handle the new gate dependency correctly.
  - Changed checkout ref from `head.ref` to `head.sha` for safer pinned checkout.
  - Bumped `actions/checkout` from `v5` to `v6`.

* `.github/workflows/run-tests.yaml`:
  - Replaced `pull_request_target` trigger with `pull_request` since the gate-based security model is now handled in `build.yaml`.
  - Updated the `code_coverage` job condition to also run on `pull_request` events (in addition to `pull_request_target`).
  - Changed checkout ref from `head.ref` to `head.sha`.
  - Bumped `actions/checkout` from `v5` to `v6`.

* `.github/workflows/lint-markdown-links.yml`:
  - Bumped `actions/checkout` from `v5` to `v6`.

* `.github/workflows/pull-gitleaks.yml`:
  - Bumped `actions/checkout` from `v5` to `v6`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- Correlation ID: `1cd53628-821f-4629-b49c-e3f1e393e6ef`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
</details>
