### PR TITLE
Add component-config.yaml

### DIFF
--- a/component-config.yaml
+++ b/component-config.yaml
@@ -1,0 +1,4 @@
+name: kyma-project.io/kyma-runtime/kcp-components/gardener-syncer
+team: kyma/framefrog
+images:
+  - europe-docker.pkg.dev/kyma-project/prod/gardener-syncer:latest


### PR DESCRIPTION
## Summary

This PR adds a `component-config.yaml` file at the repository root, following the same pattern used by infrastructure-manager and other KCP components.

The file declares:
- The component name under `kyma-project.io/kyma-runtime/kcp-components/gardener-syncer`
- The owning team (`kyma/framefrog`)
- The list of images produced by this module (`europe-docker.pkg.dev/kyma-project/prod/gardener-syncer:latest`)

## Why

The `component-config.yaml` is required for consistent component registration and image tracking across KCP modules, enabling tooling to discover and manage the images produced by each component.